### PR TITLE
Add JSON load failure handler

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -12,6 +12,12 @@ fetch('data.json')
     solvSites = data.solvSites;
     initLeaflet();
     initCesium();
+  })
+  .catch(err => {
+    console.error(err);
+    alert('Failed to load data');
+    const el = document.getElementById('errorMessage');
+    if (el) el.classList.remove('hidden');
   });
 
 function contactUrl(company) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,6 +25,7 @@
   <button id="btn3d" class="toggle-btn">3D Globe</button>
   <label class="flex items-center space-x-1 ml-2"><input type="checkbox" id="themeToggle"><span class="text-sm">Dark Mode</span></label>
 </div>
+<div id="errorMessage" class="absolute z-10 bottom-0 left-0 m-2 p-2 bg-red-200 text-red-800 hidden">Failed to load data.</div>
 <div id="map"></div>
 <div id="cesiumContainer"></div>
 <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js"></script>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <button id="btn3d" class="toggle-btn">3D Globe</button>
   <label class="flex items-center space-x-1 ml-2"><input type="checkbox" id="themeToggle"><span class="text-sm">Dark Mode</span></label>
 </div>
+<div id="errorMessage" class="absolute z-10 bottom-0 left-0 m-2 p-2 bg-red-200 text-red-800 hidden">Failed to load data.</div>
 <div id="map"></div>
 <div id="cesiumContainer"></div>
 <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js"></script>
@@ -51,6 +52,10 @@ Promise.all([
   solvSites=solvData.map(r=>({name:r['SOLV BESS PROJECT'],capacity:r['MW AC Capacity'],client:r['Client'],lat:parseFloat(r['Latitude']),lon:parseFloat(r['Longitude'])}));
   initLeaflet();
   initCesium();
+}).catch(err=>{
+  console.error(err);
+  alert('Failed to load data');
+  document.getElementById('errorMessage').classList.remove('hidden');
 });
 function contactUrl(company){return 'https://www.google.com/search?q='+encodeURIComponent(company+' contact information');}
 function mapUrl(company,county,state){return 'https://www.google.com/maps/search/'+encodeURIComponent(company+', '+county+' County, '+state);}


### PR DESCRIPTION
## Summary
- show an alert and console error if JSON loading fails
- add a small on-page error notice element

## Testing
- `python -m py_compile parse_excel.py`

------
https://chatgpt.com/codex/tasks/task_e_68835799fb908322baea65cd2225ce2c