### PR TITLE
Update README to use full index URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,4 @@ Serve the repository via a local HTTP server and open the app in your browser:
 python -m http.server
 ```
 
-Then navigate to `http://localhost:8000/` which will redirect to
-`frontend/index.html`.
+Then browse to `http://localhost:8000/frontend/index.html` to open the app.


### PR DESCRIPTION
## Summary
- clarify instructions in `README` for direct access to `frontend/index.html`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68835f3fb1988322a3bdd20de046cc02